### PR TITLE
Use get_data in GrantAssistant test

### DIFF
--- a/tests/AI/GrantAssistantTest.php
+++ b/tests/AI/GrantAssistantTest.php
@@ -48,8 +48,9 @@ class GrantAssistantTest extends TestCase {
                 $req->set_param( 'tone', 'grant' );
                 $req->set_param( 'source', 'Community arts event.' );
 
-                $res = GrantAssistant::generate( $req );
-                $this->assertStringContainsString( 'Community arts event.', $res['draft'] );
-                $this->assertStringContainsString( '<p>', $res['output'] );
+               $res  = GrantAssistant::generate( $req );
+               $data = $res->get_data();
+               $this->assertStringContainsString( 'Community arts event.', $data['draft'] );
+               $this->assertStringContainsString( '<p>', $data['output'] );
         }
 }


### PR DESCRIPTION
## Summary
- Capture GrantAssistant::generate() result and access response data via get_data

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: Failed opening required '/workspace/art-test/vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68baf06cc368832ebf0b8c9254d3b697