### PR TITLE
chore: update docs lint workflow actions

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -21,11 +21,11 @@ jobs:
   docs-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Validate docs


### PR DESCRIPTION
## Summary
- bump checkout action from v3 to v4
- bump setup-python action from v4 to v5

## Testing
- `npm test` *(fails: Failed opening required 'vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb0dabe068832e9a78b8c2c9c25cca