### PR TITLE
Cache npm in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - name: Start WordPress
         run: npx @wordpress/env start


### PR DESCRIPTION
## Summary
- cache npm directory in E2E workflow to speed up installs

## Testing
- `npm test` *(fails: Failed opening required '/workspace/art-test/vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bb110ae98c832e87af7dc8a71213c9