### PR TITLE
Ensure fetch mocks return successful responses in useFilteredWidgets tests

### DIFF
--- a/assets/js/__tests__/useFilteredWidgets.test.ts
+++ b/assets/js/__tests__/useFilteredWidgets.test.ts
@@ -1,13 +1,23 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import useFilteredWidgets from '../../../dashboard/useFilteredWidgets';
 
-const mockFetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ widget_roles: {} }) })) as any;
+const mockFetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ widget_roles: {} }),
+  })
+) as any;
 (globalThis as any).fetch = mockFetch;
 
 beforeEach(() => {
   mockFetch.mockReset();
   mockFetch.mockImplementation(() =>
-    Promise.resolve({ json: () => Promise.resolve({ widget_roles: {} }) })
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ widget_roles: {} }),
+    })
   );
 });
 
@@ -28,24 +38,35 @@ test('includes widgets with no allowed roles for any user', () => {
 });
 
 test('includes REST-only widgets as stubs', async () => {
-  mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ widget_roles: { gamma: ['member'] } }) });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ widget_roles: { gamma: ['member'] } }),
+  });
   const { result } = renderHook(() => useFilteredWidgets([{ id: 'alpha', roles: ['member'] }], { roles: ['member'] }));
   await waitFor(() => expect(result.current.widgets.some(w => w.id === 'gamma')).toBe(true));
   expect(result.current.widgets.find(w => w.id === 'gamma')?.restOnly).toBe(true);
 });
 
 test('includes REST-only widgets with no allowed roles for any user', async () => {
-  mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ widget_roles: { gamma: [] } }) });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ widget_roles: { gamma: [] } }),
+  });
   const { result } = renderHook(() => useFilteredWidgets([], { roles: ['member'] }));
   await waitFor(() => expect(result.current.widgets.some(w => w.id === 'gamma')).toBe(true));
 });
 
 test('omits widgets when preview role lacks capability', async () => {
   mockFetch.mockResolvedValueOnce({
-    json: () => Promise.resolve({
-      widget_roles: { alpha: ['member'] },
-      capabilities: { alpha: 'edit_posts' },
-    }),
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        widget_roles: { alpha: ['member'] },
+        capabilities: { alpha: 'edit_posts' },
+      }),
   });
   const widgets = [{ id: 'alpha', roles: ['member'] }];
   const { result } = renderHook(() =>
@@ -56,6 +77,8 @@ test('omits widgets when preview role lacks capability', async () => {
 
 test('omits widgets when preview role is excluded', async () => {
   mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
     json: () =>
       Promise.resolve({
         widget_roles: { beta: ['member'] },


### PR DESCRIPTION
## Summary
- include `ok` and `status` fields in default `mockFetch` response
- return successful responses in each test's fetch mock

## Testing
- `npm run test:js -- assets/js/__tests__/useFilteredWidgets.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb18e79d14832e95640c56fe210bda