### PR TITLE
Await hook updates in widget filter tests

### DIFF
--- a/assets/js/__tests__/useFilteredWidgets.test.ts
+++ b/assets/js/__tests__/useFilteredWidgets.test.ts
@@ -28,13 +28,17 @@ test('returns widgets matching any user role', async () => {
     { id: 'shared', roles: ['member', 'artist'] },
   ];
   const { result } = renderHook(() => useFilteredWidgets(widgets, { roles: ['member', 'artist'] }));
-  expect(result.current.widgets.map(w => w.id)).toEqual(['alpha', 'beta', 'shared']);
+  await waitFor(() =>
+    expect(result.current.widgets.map(w => w.id)).toEqual(['alpha', 'beta', 'shared'])
+  );
 });
 
-test('includes widgets with no allowed roles for any user', () => {
+test('includes widgets with no allowed roles for any user', async () => {
   const widgets = [{ id: 'alpha' }];
   const { result } = renderHook(() => useFilteredWidgets(widgets, { roles: ['member'] }));
-  expect(result.current.widgets.map(w => w.id)).toEqual(['alpha']);
+  await waitFor(() =>
+    expect(result.current.widgets.map(w => w.id)).toEqual(['alpha'])
+  );
 });
 
 test('includes REST-only widgets as stubs', async () => {


### PR DESCRIPTION
## Summary
- wait for useFilteredWidgets hook results before asserting
- test that widgets with no roles are retrieved after async updates

## Testing
- `npm test -- assets/js/__tests__/useFilteredWidgets.test.ts` *(fails: Failed opening required 'vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb1af46bb4832e86769254107fecb8