### PR TITLE
test: handle fetch errors

### DIFF
--- a/assets/js/__tests__/useFilteredWidgets.test.ts
+++ b/assets/js/__tests__/useFilteredWidgets.test.ts
@@ -106,6 +106,28 @@ test('reports loading state', async () => {
   await waitFor(() => expect(result.current.loading).toBe(false));
 });
 
+test('sets error when fetch rejects and keeps widgets unchanged', async () => {
+  mockFetch.mockRejectedValueOnce(new Error('Network error'));
+  const widgets = [{ id: 'alpha', roles: ['member'] }];
+  const { result } = renderHook(() =>
+    useFilteredWidgets(widgets, { roles: ['member'] })
+  );
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await waitFor(() => expect(result.current.error).not.toBeNull());
+  expect(result.current.widgets.map(w => w.id)).toEqual(['alpha']);
+});
+
+test('sets error when fetch returns non-ok response', async () => {
+  mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+  const widgets = [{ id: 'alpha', roles: ['member'] }];
+  const { result } = renderHook(() =>
+    useFilteredWidgets(widgets, { roles: ['member'] })
+  );
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await waitFor(() => expect(result.current.error).toMatch(/500/));
+  expect(result.current.widgets.map(w => w.id)).toEqual(['alpha']);
+});
+
 test('aborts fetch on unmount', () => {
   let aborted = false;
   mockFetch.mockImplementationOnce((url: any, { signal }: any) => {


### PR DESCRIPTION
## Summary
- add tests for fetch rejection and non-ok responses in useFilteredWidgets

## Testing
- `npm test` *(fails: Failed opening required '/workspace/art-test/vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*
- `npm run test:js`


------
https://chatgpt.com/codex/tasks/task_e_68bb1fe9a94c832ead515d68e47360c0