### PR TITLE
Add Tasks widget test

### DIFF
--- a/assets/ts/dashboard/widgets/__tests__/Tasks.test.tsx
+++ b/assets/ts/dashboard/widgets/__tests__/Tasks.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Tasks from '../Tasks';
+
+describe('Tasks', () => {
+  it('toggles task done state and line-through class when checkbox clicked', () => {
+    render(<Tasks />);
+    const checkbox = screen.getByRole('checkbox', { name: /finish portfolio/i });
+    const text = screen.getByText('Finish portfolio');
+
+    expect(checkbox).not.toBeChecked();
+    expect(text).not.toHaveClass('line-through');
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    expect(text).toHaveClass('line-through');
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(text).not.toHaveClass('line-through');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for Tasks dashboard widget verifying checkbox toggles done state and line-through class

## Testing
- `npm test` *(fails: Failed opening required 'wordpress/wp-settings.php')*
- `npm run test:js`

------
https://chatgpt.com/codex/tasks/task_e_68bb1ff10950832e8cc05fdcf57774be