### PR TITLE
chore: update babel config

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,8 +1,9 @@
 module.exports = {
   presets: [
-    '@babel/preset-env',
+    ['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }],
     ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
+  sourceType: 'unambiguous',
   plugins: ['@babel/plugin-transform-optional-chaining'],
 };


### PR DESCRIPTION
## Summary
- configure Babel env preset for current Node and enable unambiguous source type

## Testing
- `npm test` *(fails: Failed opening required 'vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bb28d0ce94832e9bbd33ce05305b05