### PR TITLE
chore(test): ignore compiled ts tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -27,6 +27,7 @@ const config: Config = {
     '<rootDir>/assets/js/components/__tests__/CommentThread.test.js',
     '<rootDir>/assets/js/components/__tests__/ReportDialog.test.js',
     '<rootDir>/assets/js/components/__tests__/WidgetSettingsForm.test.js',
+    '/assets/ts/.*\\.test\\.js$',
   ],
   collectCoverage: true,
   coverageDirectory: 'coverage',


### PR DESCRIPTION
## Summary
- ignore compiled TypeScript test files in Jest

## Testing
- `npm test` *(fails: Failed opening required '/workspace/art-test/vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb28d0e47c832ebfac8d35cf503eab