### PR TITLE
test: mock fetch in jest setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
     '<rootDir>/src/components',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  setupFilesAfterEnv: ['<rootDir>/tests/js/setupTests.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -36,3 +36,16 @@ if (typeof global.window !== 'undefined' && typeof global.window.localStorage ==
     writable: true,
   });
 }
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ widgets: [], filters: [] }),
+    })
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});


### PR DESCRIPTION
## Summary
- mock global `fetch` in Jest setup to return empty widgets and filters
- reset all Jest mocks after each test
- configure Jest to use the new `jest.setup.js`

## Testing
- `npm run test:js` *(fails: Test Suites: 1 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28d10e30832e84854f08abe5d2e1