### PR TITLE
docs(qa): add testing matrix and testing guides

### DIFF
--- a/docs/dev/rest-testing-guide.md
+++ b/docs/dev/rest-testing-guide.md
@@ -1,0 +1,32 @@
+---
+title: REST Testing Guide
+category: developer
+role: developer
+last_updated: 2025-08-03
+status: draft
+---
+
+# REST Testing Guide
+
+## Spin Up Test Environment
+Use the plugin's PHPUnit environment or `npm run test:php:up` to start a WordPress instance with tests tables.
+
+## Hitting Routes with `WP_REST_Request`
+```php
+$request  = new WP_REST_Request( 'GET', '/my-plugin/v1/example' );
+$response = rest_do_request( $request );
+```
+
+## Assertions
+- Expect `401` or `403` for unauthenticated requests.
+- Grant permissions and expect `200` for authorized requests.
+- Validate returned data against the route schema.
+
+## Sample Test
+```php
+public function test_route_requires_auth() {
+    $request  = new WP_REST_Request( 'GET', '/my-plugin/v1/example' );
+    $response = rest_do_request( $request );
+    $this->assertSame( 401, $response->get_status() );
+}
+```

--- a/docs/qa/coverage-policy.md
+++ b/docs/qa/coverage-policy.md
@@ -1,0 +1,21 @@
+---
+title: Coverage Policy
+category: qa
+role: qa
+last_updated: 2025-08-03
+status: draft
+---
+
+# Coverage Policy
+
+## Thresholds
+- PHP ≥ 80%
+- JavaScript ≥ 80%
+- E2E tests cover critical flows
+
+## Exclusions
+- Generated code
+- Index files
+
+## Enforcement
+Pull requests failing thresholds must be fixed before merge.

--- a/docs/qa/how-to-run-tests.md
+++ b/docs/qa/how-to-run-tests.md
@@ -1,0 +1,34 @@
+---
+title: How to Run Tests
+category: qa
+role: qa
+last_updated: 2025-08-03
+status: draft
+---
+
+# How to Run Tests
+
+## Setup
+```bash
+composer install
+npm ci
+```
+
+## Linting and Type Checks
+```bash
+vendor/bin/phpcs
+npm run lint:js
+npm run typecheck
+```
+
+## Test Commands
+```bash
+npm run test:js -- --coverage
+npm run test:php
+npm run test:e2e
+```
+
+## Troubleshooting
+- Reset the WordPress test database if migrations fail.
+- Use headless mode when Cypress cannot open a browser.
+- Configure `XDEBUG_MODE=coverage` for coverage reports.

--- a/docs/qa/testing-matrix.md
+++ b/docs/qa/testing-matrix.md
@@ -1,0 +1,35 @@
+---
+title: Testing Matrix
+category: qa
+role: qa
+last_updated: 2025-08-03
+status: draft
+---
+
+# Testing Matrix
+
+## Supported Environments
+- PHP 8.1–8.3
+- WordPress 6.3–latest
+- MySQL 5.7 & 8.0
+- Modern browsers
+
+## Pipelines
+- Pull Request
+- Nightly
+- Tag
+
+## Blocking Checks
+- Coding standards
+- Type checks
+- Unit, integration, and end-to-end tests
+- Coverage thresholds
+
+## Version Policy
+- Track latest WordPress and PHP within supported ranges
+- Maintain compatibility with MySQL 5.7 and 8.0
+
+## Data Stores
+- WordPress database tables
+- Transients and options
+- Custom plugin tables


### PR DESCRIPTION
## Summary
- add QA testing matrix
- document how to run tests
- define coverage policy
- outline REST testing guide

## Testing
- `npm test` *(fails: Missing /workspace/art-test/vendor/wp-phpunit/wp-phpunit/wordpress/wp-settings.php)*
- `npm run test:js -- --coverage` *(fails: 1 suite failed, 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3383f820832ea10e552cd2ca17b8