### PR TITLE
test(coverage): enforce PHP and JS coverage thresholds and outputs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,6 +33,9 @@ const config: Config = {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageReporters: ['json', 'lcov', 'text'],
+  coverageThreshold: {
+    global: { branches: 80, functions: 80, lines: 80, statements: 80 }
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "lint:test-groups": "node tools/validate-test-groups.js",
-    "test:php": "npm run lint:test-groups && vendor/bin/phpunit -c phpunit.unit.xml.dist --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit-unit.xml && vendor/bin/phpunit -c phpunit.wp.xml.dist --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit-unit.xml",
+    "test:php": "npm run lint:test-groups && vendor/bin/phpunit -c phpunit.unit.xml.dist --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit.xml && vendor/bin/phpunit -c phpunit.wp.xml.dist --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit.xml",
     "test:php:up": "docker compose -f docker-compose.tests.yml up -d",
     "test:php:down": "docker compose -f docker-compose.tests.yml down -v",
     "test:php:local": "npm run test:php:up && composer test:php:local; npm run test:php:down",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" failOnLowCoverage="true" minCoverage="80">
   <php>
     <env name="WP_PHPUNIT__DIR" value="vendor/wp-phpunit/wp-phpunit"/>
   </php>
+
+  <coverage>
+    <report>
+      <clover outputFile="build/coverage-phpunit.xml"/>
+    </report>
+  </coverage>
+
   <testsuites>
     <testsuite name="AI">
       <directory suffix="Test.php">tests/AI</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" failOnLowCoverage="true" minCoverage="80">
   <php>
     <env name="WP_PHPUNIT__TESTS_DIR" value="vendor/wp-phpunit/wp-phpunit"/>
   </php>
+
+  <coverage>
+    <report>
+      <clover outputFile="build/coverage-phpunit.xml"/>
+    </report>
+  </coverage>
+
   <testsuites>
     <testsuite name="Plugin Test Suite">
       <directory suffix="Test.php">tests</directory>


### PR DESCRIPTION
## Summary
- enforce PHP coverage floors and output path in phpunit configs
- require 80% JS coverage globally
- centralize PHP coverage artifact path

## Testing
- `npm run test:js -- --coverage` *(fails: global coverage threshold not met)*
- `npm run test:php` *(fails: invalid @group annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb36f11ecc832e8bf28c077625f2b3