### PR TITLE
Add PHPUnit base for REST with sample route test

### DIFF
--- a/tests/Rest/ExampleRouteTest.php
+++ b/tests/Rest/ExampleRouteTest.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/RouteTestCase.php';
+
+/**
+ * @group REST
+ */
+class ExampleRouteTest extends RouteTestCase {
+    public function test_users_me_route() {
+        $response = $this->req( 'GET', '/wp/v2/users/me' );
+        $this->assertSame( 401, $response->get_status() );
+
+        $user_id = self::factory()->user->create();
+        $response = $this->req( 'GET', '/wp/v2/users/me', [], $user_id );
+        $this->assertSame( 200, $response->get_status() );
+
+        $data = $response->get_data();
+        $this->assertArrayHasKey( 'id', $data );
+        $this->assertArrayHasKey( 'name', $data );
+    }
+}

--- a/tests/Rest/RouteTestCase.php
+++ b/tests/Rest/RouteTestCase.php
@@ -1,0 +1,9 @@
+<?php
+class RouteTestCase extends WP_UnitTestCase {
+    protected function req( string $method, string $path, array $params=[], int $user=0 ) {
+        wp_set_current_user( $user );
+        $request = new WP_REST_Request( strtoupper($method), $path );
+        foreach ($params as $k=>$v) { $request->set_param($k,$v); }
+        return rest_do_request( $request );
+    }
+}


### PR DESCRIPTION
## Summary
- add RouteTestCase for a minimal REST request helper
- introduce ExampleRouteTest verifying /wp/v2/users/me access and schema

## Testing
- `npm run test:php` *(fails: missing @group in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3837a774832eb5946aa4ae7c2fea