### PR TITLE
build: guard check integration and phpcs tuning

### DIFF
--- a/docs/qa/how-to-run-tests.md
+++ b/docs/qa/how-to-run-tests.md
@@ -21,6 +21,17 @@ npm run lint:js
 npm run typecheck
 ```
 
+## Codex Checks
+The Codex pipeline includes a widget guard checker that prevents widgets from rendering during dashboard builder previews.
+Run it in check mode via:
+```bash
+npm run codex:checks
+```
+Use the `--fix` flag to insert missing guards automatically:
+```bash
+python3 scripts/widget-preview-guard-check.py --fix
+```
+
 ## Test Commands
 ```bash
 npm run test:js -- --coverage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:js": "jest --runInBand --coverage",
     "test:e2e:smoke": "node scripts/spin-wp.js && cypress run --spec \"cypress/e2e/**/smoke*.cy.{js,ts}\" || echo \"(optional)\"",
     "test": "npm run lint:php && npm run lint:js && npm run typecheck && npm run test:js && npm run test:php",
-    "codex:checks": "php codex/checks/widget-preview-guard.php && php codex/checks/rest-contracts.php && php codex/checks/migrations.php && php codex/checks/widgets-contracts.php && python3 scripts/docs_validate.py",
+    "codex:checks": "python3 scripts/widget-preview-guard-check.py --check && php codex/checks/widget-preview-guard.php && php codex/checks/rest-contracts.php && php codex/checks/migrations.php && php codex/checks/widgets-contracts.php && python3 scripts/docs_validate.py",
     "coverage:merge": "node scripts/merge-coverage.js",
     "test:rest": "vendor/bin/phpunit -c phpunit.wp.xml.dist --group restapi --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit-unit.xml",
     "test:frontend": "vendor/bin/phpunit -c phpunit.wp.xml.dist --testsuite Frontend --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit-unit.xml || vendor/bin/phpunit -c phpunit.wp.xml.dist tests/Frontend --log-junit build/junit-phpunit-unit.xml --coverage-clover build/coverage-phpunit-unit.xml",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,13 @@
   <rule ref="WordPress-Extra"/>
   <rule ref="PHPCompatibility"/>
   <exclude-pattern>vendor/*</exclude-pattern>
+  <exclude-pattern>tests/widgets/__snapshots__/*</exclude-pattern>
+  <exclude-pattern>scripts/*</exclude-pattern>
+  <exclude-pattern>dist/*</exclude-pattern>
+
+  <rule ref="Squiz.Commenting.FileComment">
+    <exclude-pattern>tests/*</exclude-pattern>
+  </rule>
 
   <severity>5</severity>
   <arg value="sp"/>

--- a/scripts/widget-preview-guard-check.py
+++ b/scripts/widget-preview-guard-check.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from pathlib import Path
 
@@ -8,77 +9,123 @@ WIDGET_DIRS = [PLUGIN_DIR / 'widgets', PLUGIN_DIR / 'templates/widgets']
 MANIFEST_PATH = PLUGIN_DIR / 'widget-manifest-with-health.json'
 REPORT_PATH = PLUGIN_DIR / 'widget-preview-report.md'
 
-changed_files = []
-widget_files = []
 
-# Scan PHP widget files and ensure guard after opening tag
-for wdir in WIDGET_DIRS:
-    for path in sorted(wdir.glob('*.php')):
-        rel = path.relative_to(PLUGIN_DIR)
-        widget_files.append(rel.as_posix())
-        lines = path.read_text().splitlines()
-        if not lines:
-            continue
-        if lines[0].strip() != '<?php':
-            continue  # html-first templates ignored
-        guarded = len(lines) > 1 and lines[1].strip() == GUARD_LINE
-        if not guarded:
-            lines.insert(1, GUARD_LINE)
-            path.write_text('\n'.join(lines) + '\n')
-            changed_files.append(rel.as_posix())
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ensure widget preview guard is present")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check mode. Exit 1 if any widget or manifest changes would occur",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Fix mode (default). Writes missing guards and updates manifest/report",
+    )
+    args = parser.parse_args()
+    fix_mode = args.fix or not args.check
 
-print(f"Scanned {len(widget_files)} widget PHP files")
-print(f"Added guard to {len(changed_files)} files")
+    changed_files: list[str] = []
+    widget_files: list[str] = []
 
-# Load manifest and update previewGuarded flag
-if MANIFEST_PATH.exists():
-    data = json.loads(MANIFEST_PATH.read_text())
-    file_to_ids = {}
-    for wid, info in data.items():
-        file_path = info.get('file', '')
-        file_to_ids.setdefault(file_path, []).append(wid)
-        preview_guarded = True
-        if file_path.endswith('.php'):
-            abs_path = PLUGIN_DIR / file_path
-            if abs_path.exists():
-                lines = abs_path.read_text().splitlines()
-                if lines and lines[0].strip() == '<?php':
-                    preview_guarded = len(lines) > 1 and lines[1].strip() == GUARD_LINE
+    # Scan PHP widget files and ensure guard after opening tag
+    for wdir in WIDGET_DIRS:
+        for path in sorted(wdir.rglob("*.php")):
+            rel = path.relative_to(PLUGIN_DIR)
+            widget_files.append(rel.as_posix())
+            lines = path.read_text().splitlines()
+            if not lines:
+                continue
+            if lines[0].strip() != "<?php":
+                continue  # html-first templates ignored
+            guarded = len(lines) > 1 and lines[1].strip() == GUARD_LINE
+            if not guarded:
+                changed_files.append(rel.as_posix())
+                if fix_mode:
+                    lines.insert(1, GUARD_LINE)
+                    path.write_text("\n".join(lines) + "\n")
+
+    print(f"Scanned {len(widget_files)} widget PHP files")
+    if fix_mode:
+        print(f"Added guard to {len(changed_files)} files")
+
+    duplicate_ids = {}
+    unmapped = []
+
+    if MANIFEST_PATH.exists():
+        data = json.loads(MANIFEST_PATH.read_text())
+        file_to_ids: dict[str, list[str]] = {}
+        for wid, info in data.items():
+            file_path = info.get("file", "")
+            file_to_ids.setdefault(file_path, []).append(wid)
+            preview_guarded = True
+            if file_path.endswith(".php"):
+                abs_path = PLUGIN_DIR / file_path
+                if abs_path.exists():
+                    lines = abs_path.read_text().splitlines()
+                    if lines and lines[0].strip() == "<?php":
+                        preview_guarded = len(lines) > 1 and lines[1].strip() == GUARD_LINE
+                    else:
+                        preview_guarded = False
                 else:
                     preview_guarded = False
-            else:
-                preview_guarded = False
-        info['previewGuarded'] = preview_guarded
-    # find duplicates and unmapped
-    duplicate_ids = {fp: ids for fp, ids in file_to_ids.items() if len(ids) > 1}
-    unmapped = sorted(set(widget_files) - set(file_to_ids.keys()))
+            if fix_mode:
+                info["previewGuarded"] = preview_guarded
+        # find duplicates and unmapped
+        duplicate_ids = {fp: ids for fp, ids in file_to_ids.items() if len(ids) > 1}
+        unmapped = sorted(set(widget_files) - set(file_to_ids.keys()))
 
-    # sort by role then id
-    sorted_items = sorted(data.items(), key=lambda kv: ((kv[1]['roles'][0] if kv[1]['roles'] else ''), kv[0]))
-    ordered = {k: v for k, v in sorted_items}
-    MANIFEST_PATH.write_text(json.dumps(ordered, indent=4) + '\n')
+        if fix_mode:
+            # sort by role then id
+            sorted_items = sorted(
+                data.items(), key=lambda kv: ((kv[1]["roles"][0] if kv[1]["roles"] else ""), kv[0])
+            )
+            ordered = {k: v for k, v in sorted_items}
+            MANIFEST_PATH.write_text(json.dumps(ordered, indent=4) + "\n")
 
-    guarded_count = sum(1 for info in ordered.values() if info.get('previewGuarded'))
-    unguarded_count = len(ordered) - guarded_count
+            guarded_count = sum(1 for info in ordered.values() if info.get("previewGuarded"))
+            unguarded_count = len(ordered) - guarded_count
 
-    with open(REPORT_PATH, 'w') as f:
-        f.write('# Widget Preview Guard Report\n\n')
-        f.write(f'Total widgets scanned: {len(widget_files)}\n')
-        f.write(f'Widgets guarded: {guarded_count}\n')
-        f.write(f'Widgets unguarded: {unguarded_count}\n')
-        if duplicate_ids:
-            f.write('\n## Duplicate IDs\n')
-            for fp, ids in duplicate_ids.items():
-                f.write(f'- {fp}: {", ".join(ids)}\n')
-        if unmapped:
-            f.write('\n## Unmapped Files\n')
-            for fp in unmapped:
-                f.write(f'- {fp}\n')
+            with open(REPORT_PATH, "w") as f:
+                f.write("# Widget Preview Guard Report\n\n")
+                f.write(f"Total widgets scanned: {len(widget_files)}\n")
+                f.write(f"Widgets guarded: {guarded_count}\n")
+                f.write(f"Widgets unguarded: {unguarded_count}\n")
+                if duplicate_ids:
+                    f.write("\n## Duplicate IDs\n")
+                    for fp, ids in duplicate_ids.items():
+                        f.write(f"- {fp}: {', '.join(ids)}\n")
+                if changed_files:
+                    f.write("\n## Files Updated\n")
+                    for cf in changed_files:
+                        f.write(f"- {cf}\n")
+
+            if unmapped:
+                print("[WARN] Unmapped widget files:")
+                for fp in unmapped:
+                    print(f" - {fp}")
+            print(f"Updated manifest at {MANIFEST_PATH}")
+            print(f"Report generated at {REPORT_PATH}")
+
+    if args.check:
         if changed_files:
-            f.write('\n## Files Updated\n')
+            print("[FAIL] Unguarded widgets detected:")
             for cf in changed_files:
-                f.write(f'- {cf}\n')
+                print(f" - {cf}")
+            if duplicate_ids:
+                print("[WARN] Duplicate widget IDs:")
+                for fp, ids in duplicate_ids.items():
+                    print(f" - {fp}: {', '.join(ids)}")
+            if unmapped:
+                print("[WARN] Unmapped widget files:")
+                for fp in unmapped:
+                    print(f" - {fp}")
+            return 1
+        return 0
 
-    print(f'Updated manifest at {MANIFEST_PATH}')
-    print(f'Report generated at {REPORT_PATH}')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
 

--- a/templates/widgets/rsvp-stats.php
+++ b/templates/widgets/rsvp-stats.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 /**
  * RSVP stats widget template.
  *

--- a/templates/widgets/spotlight-dashboard.php
+++ b/templates/widgets/spotlight-dashboard.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 /**
  * Spotlight dashboard widget template.
  *

--- a/templates/widgets/widget-my-follows.php
+++ b/templates/widgets/widget-my-follows.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 /**
  * Widget template shim for widget_my_follows.
  *

--- a/widget-manifest-with-health.json
+++ b/widget-manifest-with-health.json
@@ -30,26 +30,6 @@
         "status": "ok",
         "previewGuarded": true
     },
-    "site_stats": {
-        "file": "templates/widgets/site-stats.php",
-        "roles": [
-            "artist",
-            "member",
-            "organization",
-            "administrator"
-        ],
-        "status": "registered",
-        "previewGuarded": true
-    },
-    "artist_artwork_manager": {
-        "file": "templates/widgets/artist-artwork-manager.php",
-        "roles": [
-            "member",
-            "artist"
-        ],
-        "status": "registered",
-        "previewGuarded": true
-    },
     "artist_audience_insights": {
         "file": "templates/widgets/artist-audience-insights.php",
         "roles": [
@@ -98,15 +78,6 @@
         "status": "registered",
         "previewGuarded": true
     },
-    "messages": {
-        "file": "templates/widgets/messages.php",
-        "roles": [
-            "member",
-            "artist"
-        ],
-        "status": "registered",
-        "previewGuarded": true
-    },
     "onboarding_tracker": {
         "file": "templates/widgets/onboarding-tracker.php",
         "roles": [
@@ -131,6 +102,17 @@
         "status": "registered",
         "previewGuarded": true
     },
+    "site_stats": {
+        "file": "templates/widgets/site-stats.php",
+        "roles": [
+            "artist",
+            "member",
+            "organization",
+            "administrator"
+        ],
+        "status": "registered",
+        "previewGuarded": true
+    },
     "widget_spotlights": {
         "file": "templates/widgets/widget-spotlights.php",
         "roles": [
@@ -145,6 +127,15 @@
             "member",
             "artist",
             "organization"
+        ],
+        "status": "registered",
+        "previewGuarded": true
+    },
+    "artist_artwork_manager": {
+        "file": "templates/widgets/artist-artwork-manager.php",
+        "roles": [
+            "member",
+            "artist"
         ],
         "status": "registered",
         "previewGuarded": true
@@ -251,6 +242,15 @@
             "member",
             "artist",
             "organization"
+        ],
+        "status": "registered",
+        "previewGuarded": true
+    },
+    "messages": {
+        "file": "templates/widgets/messages.php",
+        "roles": [
+            "member",
+            "artist"
         ],
         "status": "registered",
         "previewGuarded": true
@@ -412,6 +412,14 @@
         "status": "registered",
         "previewGuarded": true
     },
+    "welcome_box": {
+        "file": "widgets/Member/WelcomeBoxWidget.php",
+        "roles": [
+            "member"
+        ],
+        "status": "ok",
+        "previewGuarded": true
+    },
     "widget_events": {
         "file": "widgets/WidgetEventsWidget.php",
         "roles": [
@@ -423,14 +431,6 @@
     },
     "widget_favorites": {
         "file": "widgets/FavoritesOverviewWidget.php",
-        "roles": [
-            "member"
-        ],
-        "status": "registered",
-        "previewGuarded": true
-    },
-    "widget_near_me_events": {
-        "file": "widgets/NearbyEventsWidget.php",
         "roles": [
             "member"
         ],
@@ -461,6 +461,14 @@
         "roles": [
             "member",
             "artist"
+        ],
+        "status": "registered",
+        "previewGuarded": true
+    },
+    "widget_near_me_events": {
+        "file": "widgets/NearbyEventsWidget.php",
+        "roles": [
+            "member"
         ],
         "status": "registered",
         "previewGuarded": true
@@ -549,7 +557,7 @@
             "organization"
         ],
         "status": "registered",
-        "previewGuarded": false
+        "previewGuarded": true
     },
     "embed_tool": {
         "file": "assets/js/widgets/EmbedToolWidget.jsx",
@@ -584,12 +592,12 @@
         "previewGuarded": true
     },
     "org_insights": {
-        "file": "src/Widgets.php",
+        "file": "widgets/OrgAnalyticsWidget.php",
         "roles": [
             "organization"
         ],
         "status": "registered",
-        "previewGuarded": false
+        "previewGuarded": true
     },
     "org_team_roster": {
         "file": "assets/js/widgets/OrgTeamRosterWidget.jsx",
@@ -662,14 +670,6 @@
             "organization"
         ],
         "status": "registered",
-        "previewGuarded": true
-    },
-    "welcome_box": {
-        "file": "widgets/member/WelcomeBoxWidget.php",
-        "roles": [
-            "member"
-        ],
-        "status": "ok",
         "previewGuarded": true
     }
 }

--- a/widget-preview-report.md
+++ b/widget-preview-report.md
@@ -1,19 +1,8 @@
 # Widget Preview Guard Report
 
-Total widgets scanned: 63
-Widgets guarded: 76
-Widgets unguarded: 4
+Total widgets scanned: 84
+Widgets guarded: 79
+Widgets unguarded: 0
 
-## Files Updated
-- widgets/ArtPulseNewsFeedWidget.php
-- widgets/DonationsWidget.php
-- widgets/DonorActivityWidget.php
-- widgets/EventsWidget.php
-- widgets/FavoritesOverviewWidget.php
-- widgets/MyUpcomingEventsWidget.php
-- widgets/OrgAnalyticsWidget.php
-- widgets/OrgWidgetSharingPanel.php
-- widgets/ProfileOverviewWidget.php
-- widgets/QAChecklistWidget.php
-- widgets/SponsorDisplayWidget.php
-- widgets/WidgetEventsWidget.php
+## Duplicate IDs
+- widgets/OrgAnalyticsWidget.php: artpulse_analytics_widget, org_insights

--- a/widgets/Member/ActivityFeedWidget.php
+++ b/widgets/Member/ActivityFeedWidget.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 namespace ArtPulse\Widgets\Member;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/widgets/Member/ArtistInboxPreviewWidget.php
+++ b/widgets/Member/ArtistInboxPreviewWidget.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 namespace ArtPulse\Widgets\Member;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/widgets/Member/EventChatWidget.php
+++ b/widgets/Member/EventChatWidget.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 namespace ArtPulse\Widgets\Member;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/widgets/Member/OrgTeamRosterWidget.php
+++ b/widgets/Member/OrgTeamRosterWidget.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 namespace ArtPulse\Widgets\Member;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/widgets/Member/WelcomeBoxWidget.php
+++ b/widgets/Member/WelcomeBoxWidget.php
@@ -1,4 +1,5 @@
 <?php
+if (defined('IS_DASHBOARD_BUILDER_PREVIEW')) return;
 namespace ArtPulse\Widgets\Member;
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- ensure widget preview guard checker supports `--check` mode and run it in codex:checks
- document guard checker usage
- tune PHPCS config to ignore test snapshots and tooling paths

## Testing
- `npm run codex:checks` *(fails: Missing REST test for includes/rest-auth-code.php)*
- `npm run test` *(fails: PHP coding standards errors)*
- `vendor/bin/phpcs -q --report=summary`

------
https://chatgpt.com/codex/tasks/task_e_68bbbfba5f54832ea3092e70ec682bff