### PR TITLE
Add runtime-discovery REST smoke test

### DIFF
--- a/tests/Rest/Generated/RestRoutesSmokeTest.php
+++ b/tests/Rest/Generated/RestRoutesSmokeTest.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../RouteTestCase.php';
+
+/**
+ * Runtime-discovery smoke test for all plugin REST routes.
+ * Ensures at least one route under our namespaces exists,
+ * basic anonymous/admin behavior doesn't 404 or auth-fail unexpectedly.
+ *
+ * @group REST
+ */
+class RestRoutesSmokeTest extends RouteTestCase {
+    /** @var array<string> */
+    protected $namespaces = [ 'artpulse/v1', 'artpulse/v2' ]; // add others if your plugin uses them
+
+    public function test_namespaces_have_routes(): void {
+        $routes = rest_get_server()->get_routes();
+        foreach ($this->namespaces as $ns) {
+            $found = false;
+            foreach (array_keys($routes) as $k) {
+                if (str_starts_with($k, '/' . $ns . '/')) { $found = true; break; }
+            }
+            $this->assertTrue($found, "No registered routes found for namespace: {$ns}");
+        }
+    }
+
+    public function test_sample_requests_anonymous_vs_admin(): void {
+        $routes = rest_get_server()->get_routes();
+        $methods = ['GET','POST','PUT','PATCH','DELETE'];
+        $tested = 0;
+        foreach ($this->namespaces as $ns) {
+            foreach (array_keys($routes) as $path) {
+                if (!str_starts_with($path, '/' . $ns . '/')) continue;
+                $tested++;
+                // Anonymous
+                $hit = false;
+                foreach ($methods as $m) {
+                    $res = rest_do_request(new WP_REST_Request($m, $path));
+                    $st = $res->get_status();
+                    if ($st !== 404) { $this->assertContains($st, [200,201,202,204,400,401,403]); $hit = true; break; }
+                }
+                if (!$hit) $this->markTestSkipped("All methods 404 for {$path}");
+                // Admin
+                $admin = self::factory()->user->create(['role'=>'administrator']);
+                wp_set_current_user($admin);
+                $hit = false;
+                foreach ($methods as $m) {
+                    $res = rest_do_request(new WP_REST_Request($m, $path));
+                    $st = $res->get_status();
+                    if ($st !== 404) { $this->assertNotContains($st, [401,403], "Admin unauthorized for {$m} {$path} (status {$st})"); $hit = true; break; }
+                }
+                if (!$hit) $this->markTestSkipped("All methods 404 for {$path}");
+            }
+        }
+        $this->assertGreaterThan(0, $tested, 'No routes tested');
+    }
+}


### PR DESCRIPTION
## Summary
- add RestRoutesSmokeTest to discover plugin REST routes at runtime and ensure no unexpected 404 or auth failures

## Testing
- ⚠️ `vendor/bin/phpunit -c phpunit.wp.xml.dist tests/Rest/Generated/RestRoutesSmokeTest.php` *(fails: Failed opening required '.../wordpress/wp-settings.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bbcd643564832e9df15c26cb38d6e1