### PR TITLE
feat: add wp data type definitions

### DIFF
--- a/assets/js/wp-global.d.ts
+++ b/assets/js/wp-global.d.ts
@@ -1,0 +1,28 @@
+export {};
+
+declare global {
+  interface WPNoticeDispatcher {
+    createNotice: (
+      status: string,
+      message: string,
+      options?: { isDismissible?: boolean }
+    ) => void;
+  }
+
+  interface WPData {
+    dispatch: (store: string) => WPNoticeDispatcher;
+  }
+
+  interface WP {
+    i18n: {
+      __: (text: string, domain?: string) => string;
+    };
+    data?: WPData;
+  }
+
+  var wp: WP;
+
+  interface Window {
+    wp?: WP;
+  }
+}


### PR DESCRIPTION
## Summary
- declare global types for wp.i18n and wp.data dispatch

## Testing
- `npm test` *(fails: A TOTAL OF 645 ERRORS AND 67 WARNINGS WERE FOUND in PHPCS)*
- `npx tsc -p . --noEmit` *(fails: Property 'APWidgetMatrix' does not exist on type 'Window')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe109dffc832e8444a1258f26ea51