### PR TITLE
chore: skip library type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "allowJs": true,
+    "skipLibCheck": true,
 
     // ✅ Required for tsconfig-paths to work
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- skip type checking of declaration files by enabling `skipLibCheck`

## Testing
- `npm test` *(fails: phpcs not found)*
- `npx tsc --noEmit -p .` *(fails: cannot find name 'wp')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe10c62f8832eb86d7b5719a48a3d