### PR TITLE
feat: add wp globals type declaration

### DIFF
--- a/assets/js/types/wp-globals.d.ts
+++ b/assets/js/types/wp-globals.d.ts
@@ -1,0 +1,9 @@
+declare const wp: any;
+declare global {
+  interface Window {
+    wp?: any;
+    wpApiSettings?: { root?: string; nonce?: string };
+    APWidgetMatrix?: { endpoint?: string; nonce?: string; apNonce?: string };
+  }
+}
+export {};


### PR DESCRIPTION
## Summary
- add `wp`/window globals type declarations for JS

## Testing
- `npm test` *(fails: PHPCBF can fix 682 sniff violations)*
- `npm run lint:js`
- `npm run typecheck` *(fails: Cannot write file ... would overwrite input file)*
- `npm run test:js` *(fails: coverage thresholds not met)*
- `npm run test:php` *(fails: missing wp-settings.php)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe106ba60832ead4e748b690fd27f