### PR TITLE
feat: add submitting state to ReactForm

### DIFF
--- a/src/components/ReactForm.jsx
+++ b/src/components/ReactForm.jsx
@@ -3,10 +3,12 @@ import React, { useState } from 'react';
 const ReactForm = ({ type = 'default' }) => {
   const [formData, setFormData] = useState({ name: '', email: '' });
   const [status, setStatus] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setStatus('Submitting...');
+    setIsSubmitting(true);
     try {
       const { ajaxurl, nonce } = window.apReactForm || {};
 
@@ -33,6 +35,8 @@ const ReactForm = ({ type = 'default' }) => {
       setStatus(result.message);
     } catch (error) {
       setStatus('There was an error submitting the form.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -54,7 +58,7 @@ const ReactForm = ({ type = 'default' }) => {
         value={formData.email}
         onChange={e => setFormData({ ...formData, email: e.target.value })}
       />
-      <button type="submit">Submit</button>
+      <button type="submit" disabled={isSubmitting}>Submit</button>
       <p>{status} {type !== 'default' ? `(${type})` : ''}</p>
     </form>
   );

--- a/src/components/__tests__/ReactForm.smoke.test.jsx
+++ b/src/components/__tests__/ReactForm.smoke.test.jsx
@@ -31,4 +31,21 @@ describe('ReactForm smoke test', () => {
 
     await waitFor(() => expect(screen.getByText('Thanks!')).toBeInTheDocument());
   });
+
+  it('shows error and disables button on failed submit', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false });
+    render(<ReactForm />);
+
+    fireEvent.submit(screen.getByRole('button', { name: /submit/i }).closest('form'));
+    const button = screen.getByRole('button', { name: /submit/i });
+    expect(button).toBeDisabled();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('There was an error submitting the form.')
+      ).toBeInTheDocument()
+    );
+
+    expect(button).not.toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent duplicate submissions by disabling the ReactForm submit button while a request is in flight
- cover failed request behaviour with a new smoke test

## Testing
- `npm run test:js src/components/__tests__/ReactForm.smoke.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbefd28408832eb40123ff3980bfb0