### PR TITLE
test: mock useFilteredWidgets once in RoleDashboard interactions

### DIFF
--- a/assets/ts/dashboard/__tests__/RoleDashboard.interactions.test.tsx
+++ b/assets/ts/dashboard/__tests__/RoleDashboard.interactions.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RoleDashboard from '../RoleDashboard';
+
+jest.mock('@/dashboard/useFilteredWidgets', () => ({
+  __esModule: true,
+  useFilteredWidgets: jest.fn(() => ({ widgets: [], error: null, retry: jest.fn() })),
+}));
+const { useFilteredWidgets: mockUseFilteredWidgets } = require('@/dashboard/useFilteredWidgets');
+
+describe('RoleDashboard interactions', () => {
+  beforeEach(() => {
+    (window as any).apDashboardData = {
+      restBase: '/',
+      nonce: '',
+      seenDashboardV2: true,
+    };
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ layout: [] }) })
+    ) as any;
+  });
+
+  it('renders without crashing', () => {
+    render(<RoleDashboard role="artist" initialEdit={false} />);
+  });
+});


### PR DESCRIPTION
## Summary
- add RoleDashboard interactions test using jest.mock
- require useFilteredWidgets only once to avoid redeclaration

## Testing
- `npx jest assets/ts/dashboard/__tests__/RoleDashboard.interactions.test.tsx` *(coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5ac7080832e824a55a3579259ea