### PR TITLE
Handle custom dashboard bootstrap event

### DIFF
--- a/assets/ts/dashboard/index.entry.test.tsx
+++ b/assets/ts/dashboard/index.entry.test.tsx
@@ -1,0 +1,18 @@
+import { createRoot } from 'react-dom/client';
+
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn(),
+}));
+jest.mock('./RoleDashboard', () => () => null);
+
+describe('dashboard entry bootstrap', () => {
+  it('renders on custom bootstrap event', async () => {
+    const render = jest.fn();
+    (createRoot as jest.Mock).mockReturnValue({ render });
+    document.body.innerHTML = '<div id="ap-dashboard-root"></div>';
+    await import('./index');
+    document.dispatchEvent(new Event('ap-dashboard-bootstrap'));
+    expect(createRoot).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/ts/dashboard/index.tsx
+++ b/assets/ts/dashboard/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import RoleDashboard, { Role } from './RoleDashboard';
 
-document.addEventListener('DOMContentLoaded', () => {
+const bootstrap = () => {
   const el = document.getElementById('ap-dashboard-root');
   if (!el) return;
   const roleAttr = el.getAttribute('data-role');
@@ -10,5 +10,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const role = (roleAttr || data?.role || 'member') as Role;
   const root = createRoot(el);
   root.render(<RoleDashboard role={role} />);
-});
+};
+
+document.addEventListener('DOMContentLoaded', bootstrap);
+document.addEventListener('ap-dashboard-bootstrap', bootstrap);
 


### PR DESCRIPTION
## Summary
- Support custom `ap-dashboard-bootstrap` event in dashboard entry
- Add test ensuring bootstrap event triggers React render

## Testing
- `npx jest assets/ts/dashboard/index.entry.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5a3ae04832eb9adeeeeb6531b52