### PR TITLE
feat: add optional upcoming events prop typing

### DIFF
--- a/assets/ts/dashboard/widgets/UpcomingEvents.tsx
+++ b/assets/ts/dashboard/widgets/UpcomingEvents.tsx
@@ -6,7 +6,11 @@ export interface EventItem {
   startsAt: string;
 }
 
-export default function UpcomingEvents({ events = [] }: { events: EventItem[] }) {
+export interface UpcomingEventsProps {
+  events?: EventItem[];
+}
+
+export default function UpcomingEvents({ events = [] }: UpcomingEventsProps) {
   const items = events.map(evt => <li key={evt.id}>{evt.title}</li>);
   // istanbul ignore next
   return events.length === 0 ? (

--- a/assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx
+++ b/assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import UpcomingEvents from '../UpcomingEvents';
+import UpcomingEvents, { EventItem } from '../UpcomingEvents';
 
-const EVTS = [
+const EVTS: EventItem[] = [
   { id: 'e1', title: 'Opening Night', startsAt: new Date().toISOString() },
   { id: 'e2', title: 'Members Meetup', startsAt: new Date(Date.now() + 86400000).toISOString() },
 ];
 
 test('lists upcoming events when present', () => {
-  render(<UpcomingEvents events={EVTS as any} />);
+  render(<UpcomingEvents events={EVTS} />);
   expect(screen.getByText(/opening night/i)).toBeInTheDocument();
   expect(screen.getByText(/members meetup/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add `UpcomingEventsProps` interface with optional `events` and default empty array
- type UpcomingEvents tests using `EventItem`

## Testing
- `npm run test:js -- assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc247f19d8832eaafd6a42e541f347