### PR TITLE
test: remove unnecessary ts-expect-error

### DIFF
--- a/assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx
+++ b/assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx
@@ -20,7 +20,6 @@ test('shows empty state with no events', () => {
 });
 
 test('uses empty state when events prop omitted', () => {
-  // @ts-expect-error testing default prop behavior
   render(<UpcomingEvents />);
   expect(screen.getByText(/no upcoming events/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- remove stale `ts-expect-error` from UpcomingEvents test

## Testing
- `npx jest --coverage=false assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx`
- `npx eslint assets/ts/dashboard/widgets/__tests__/UpcomingEvents.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc286298d0832e90f2fac3f29b1760