### PR TITLE
Enable JSON module resolution for schema test

### DIFF
--- a/tests/js/dashboard-config-schema.test.ts
+++ b/tests/js/dashboard-config-schema.test.ts
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
-import schema from '../../schema/dashboard-config.schema.json' assert { type: 'json' };
-import sample from './fixtures/dashboard-config.json' assert { type: 'json' };
+import schema from '../../schema/dashboard-config.schema.json';
+import sample from './fixtures/dashboard-config.json';
 
 describe('dashboard-config schema', () => {
   it('validates sample response', () => {

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowJs": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     // ✅ Required for tsconfig-paths to work
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- allow importing JSON modules in TypeScript configs
- drop JSON import assertions in dashboard-config schema test

## Testing
- `npm run test:js` *(fails: coverage threshold not met)*
- `npx jest tests/js/dashboard-config-schema.test.ts --runInBand --coverage=false`
- `npx eslint tests/js/dashboard-config-schema.test.ts tsconfig.json tsconfig.jest.json` *(warnings: files ignored)*
- `npm run typecheck` *(fails: existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc28621d24832e8da1b00c8d84c937