### PR TITLE
fix: add Node types and ESM setup for Jest

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
 
 if (typeof (global as any).TextEncoder === 'undefined') {
-  const util = require('util');
-  (global as any).TextEncoder = util.TextEncoder;
-  (global as any).TextDecoder = util.TextDecoder;
+  (global as any).TextEncoder = TextEncoder;
+  (global as any).TextDecoder = TextDecoder;
 }
 
 // Polyfill localStorage in Jest tests when missing

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.0.0",
         "@types/jest": "^29.5.14",
+        "@types/node": "^24.3.1",
         "@types/react": "^18.3.24",
         "@types/react-dom": "^18.3.7",
         "@types/testing-library__jest-dom": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.0.0",
     "@types/jest": "^29.5.14",
+    "@types/node": "^24.3.1",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "@types/testing-library__jest-dom": "^6.0.0",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "isolatedModules": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   }
 }


### PR DESCRIPTION
## Summary
- include `@types/node` so Jest tests recognize TextEncoder/TextDecoder
- declare Node and Jest types for test builds
- switch `jest.setup.ts` to ESM to assign TextEncoder/TextDecoder globally

## Testing
- `npm test` *(fails: phpcs: not found)*
- `npm run test:js`


------
https://chatgpt.com/codex/tasks/task_e_68bc2e8371a0832e9b224aa6f0d474a4