### PR TITLE
fix: ensure jest setup compiles in esm mode

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
 
 if (typeof (global as any).TextEncoder === 'undefined') {
-  const util = require('util');
-  (global as any).TextEncoder = util.TextEncoder;
-  (global as any).TextDecoder = util.TextDecoder;
+  (global as any).TextEncoder = TextEncoder;
+  (global as any).TextDecoder = TextDecoder as any;
 }
 
 // Polyfill localStorage in Jest tests when missing


### PR DESCRIPTION
## Summary
- use ESM-friendly import for TextEncoder/TextDecoder in Jest setup to avoid runtime compile errors

## Testing
- `npm test` *(fails: A TOTAL OF 645 ERRORS AND 67 WARNINGS WERE FOUND IN 18 FILES)*
- `npm run test:js`
- `npm run lint:js` *(fails: 289 problems (289 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e88367c832eaecdf169e3f68b09